### PR TITLE
fix: restore poetry export in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.10 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry
+# Install poetry plus the export plugin so `poetry export` remains available
+RUN pip install poetry poetry-plugin-export
 
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 


### PR DESCRIPTION
## Summary
- install poetry-plugin-export so docker build can run poetry export